### PR TITLE
Change Fill command logic

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FillCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FillCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CALLER_NUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -17,7 +19,9 @@ public class FillCommand extends Command {
     // TODO - add params description, district, callerNumber if we are going with single-step fill instead of prompts
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an incident report to the incident management "
             + "system." + "Parameters: "
-            + PREFIX_CALLER_NUMBER + "CALLER NUMBER ";
+            + PREFIX_CALLER_NUMBER + "CALLER NUMBER "
+            + PREFIX_LOCATION + "DISTRICT "
+            + PREFIX_DESCRIPTION + "DESCRIPTION ";
 
     public static final String MESSAGE_SUCCESS = "New incident report added: %1$s";
     public static final String MESSAGE_DUPLICATE_REPORT = "This report already exists in the incident "

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,5 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PASSWORD = new Prefix("w/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_CALLER_NUMBER = new Prefix("c/");
-
+    public static final Prefix PREFIX_LOCATION = new Prefix("l/");
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
 }

--- a/src/main/java/seedu/address/logic/parser/FillCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FillCommandParser.java
@@ -2,13 +2,17 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CALLER_NUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FillCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.incident.CallerNumber;
+import seedu.address.model.incident.Description;
 import seedu.address.model.incident.Incident;
+import seedu.address.model.vehicle.District;
 
 /**
  * Parses input arguments and creates a new FillCommand object
@@ -21,17 +25,20 @@ public class FillCommandParser implements Parser<FillCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FillCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CALLER_NUMBER);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CALLER_NUMBER, PREFIX_LOCATION,
+                PREFIX_DESCRIPTION);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_CALLER_NUMBER)
+        if (!arePrefixesPresent(argMultimap, PREFIX_CALLER_NUMBER, PREFIX_LOCATION, PREFIX_DESCRIPTION)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FillCommand.MESSAGE_USAGE));
         }
 
         CallerNumber callerNumber = ParserUtil.parseCallerNumber(argMultimap.getValue(PREFIX_CALLER_NUMBER).get());
+        District location = ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get());
+        Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
 
         // create new incident
-        Incident incident = new Incident(callerNumber);
+        Incident incident = new Incident(callerNumber, location, description);
 
         return new FillCommand(incident);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,12 +10,14 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.incident.CallerNumber;
+import seedu.address.model.incident.Description;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Password;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Username;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.vehicle.District;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -148,9 +150,40 @@ public class ParserUtil {
     public static CallerNumber parseCallerNumber(String callerNumber) throws ParseException {
         requireNonNull(callerNumber);
         String trimmedCallerNumber = callerNumber.trim();
-        if (!CallerNumber.isValidPhone(callerNumber)) {
+        if (!CallerNumber.isValidPhone(trimmedCallerNumber)) {
             throw new ParseException(CallerNumber.MESSAGE_CONSTRAINTS);
         }
         return new CallerNumber(trimmedCallerNumber);
+    }
+
+    /**
+     * Parses a {@code String location} into a {@code District}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code location} is invalid.
+     */
+    public static District parseLocation(String location) throws ParseException {
+        requireNonNull(location);
+        String trimmedLocation = location.trim();
+        Integer trimmedLocationIndex = Integer.parseInt((trimmedLocation));
+        if (!District.isValidDistrict(trimmedLocationIndex)) {
+            throw new ParseException(CallerNumber.MESSAGE_CONSTRAINTS);
+        }
+        return new District(trimmedLocationIndex);
+    }
+
+    /**
+     * Parses a {@code String description} into a {@code Description}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code description} is invalid.
+     */
+    public static Description parseDescription(String description) throws ParseException {
+        requireNonNull(description);
+        String trimmedDescription = description.trim();
+        if (!Description.isValidDescription(trimmedDescription)) {
+            throw new ParseException(Description.MESSAGE_CONSTRAINTS);
+        }
+        return new Description(trimmedDescription);
     }
 }

--- a/src/main/java/seedu/address/model/incident/Description.java
+++ b/src/main/java/seedu/address/model/incident/Description.java
@@ -1,9 +1,22 @@
 package seedu.address.model.incident;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 /**
  * Represents the description of the incident.
  */
 public class Description {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Description can take any values, and it should not be blank";
+
+    /**
+     * The first character of the description must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
     private String desc;
 
     /**
@@ -11,6 +24,8 @@ public class Description {
      * @param desc the description of the event filled in by the operator.
      */
     public Description(String desc) {
+        requireNonNull(desc);
+        checkArgument(isValidDescription(desc), MESSAGE_CONSTRAINTS);
         this.desc = desc;
     }
 
@@ -20,6 +35,13 @@ public class Description {
      */
     public Description() {
         this.desc = "";
+    }
+
+    /**
+     * Returns true if a given string is a valid description.
+     */
+    public static boolean isValidDescription(String test) {
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/incident/Incident.java
+++ b/src/main/java/seedu/address/model/incident/Incident.java
@@ -36,16 +36,17 @@ public class Incident {
      * Creates a new Incident report, fields will be filled in through prompts in the GUI.
      * @param callerNumber is the phone number of the caller that reported the incident.
      */
-    public Incident(CallerNumber callerNumber) {
+    public Incident(CallerNumber callerNumber, District location, Description description) {
         //this.operator = autofilled on sign in
         // TODO: autofill operator upon sign in. Currently dummy data
         this.operator = new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 getTagSet("friends"), new Username("user1"), new Password("pass123"));
         this.incidentDateTime = new IncidentDateTime();
         this.id = new IncidentId(incidentDateTime.getMonth(), incidentDateTime.getYear());
-        this.incidentDesc = promptForDescription();
-        this.location = promptForLocation();
-        this.callerNumber = callerNumber; // changed by Atharv - incident constructor takes in CallerNumber, not String
+        // changed by Atharv - incident constructor takes in CallerNumber, District, and Description, not String
+        this.incidentDesc = description;
+        this.location = location;
+        this.callerNumber = callerNumber;
         //this.car = VehicleAssigner.assignVehicle(location);
     }
 

--- a/src/main/java/seedu/address/model/vehicle/District.java
+++ b/src/main/java/seedu/address/model/vehicle/District.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class District {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Districts should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Districts should be an integer from 1 to 28";
 
     public static final int FIRST_DISTRICT = 1;
     public static final int LAST_DISTRICT = 28;


### PR DESCRIPTION
Resolves #82 

Fill command now requires operator to enter caller number, location, and description fields. The report is submitted and added to the incident management system immediately upon executing the command. In Milestone 1.3, @tirameshu and @atharvjoshi will separate the 'fill' and 'submit' command in order to allow operators to temporarily save draft reports for editing before submission (Issues #84 #85). 