### PR TITLE
Improve fill and submit command logic and implementation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListIncidentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListIncidentsCommand.java
@@ -2,23 +2,99 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INCIDENTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_COMPLETE_INCIDENT_REPORTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_DRAFT_INCIDENT_REPORTS;
 
+import java.util.function.Predicate;
+
+import javafx.collections.transformation.FilteredList;
 import seedu.address.model.Model;
+import seedu.address.model.incident.Incident;
 
 /**
- * Lists all incidents in the address book to the user.
+ * Lists incidents in the address book to the user according to specified predicate.
  */
 public class ListIncidentsCommand extends Command {
 
     public static final String COMMAND_WORD = "list-i";
 
-    public static final String MESSAGE_SUCCESS = "Listed all incidents";
+    public static final String MESSAGE_ALL_INCIDENTS = "Listed all incidents";
+    private static final String MESSAGE_NO_INCIDENTS = "No incident reports present in the system";
+    private static final String MESSAGE_ALL_DRAFT_INCIDENTS = "Listed all draft incident reports";
+    private static final String MESSAGE_NO_DRAFTS_TO_FILL = "No drafts present in the system";
+    private static final String MESSAGE_ALL_COMPLETE_INCIDENTS = "Listed all incident reports ready for submission";
+    private static final String MESSAGE_NO_INCIDENT_TO_SUBMIT = "No reports ready for submission present in the system";
+    private static final String MESSAGE_FAIL = "Invalid use of command";
 
+    private final Predicate<Incident> predicate;
+
+    public ListIncidentsCommand(Predicate<Incident> predicate) {
+        this.predicate = predicate;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredIncidentList(PREDICATE_SHOW_ALL_INCIDENTS);
-        return new CommandResult(MESSAGE_SUCCESS);
+
+        // get the filtered list before updating it.
+        FilteredList<Incident> filteredIncidentsList = model.getFilteredIncidentList().filtered(predicate);
+
+        String resultMessage;
+        if (this.predicate.equals(PREDICATE_SHOW_ALL_INCIDENTS)) {
+            resultMessage = handleAllIncidents(model, filteredIncidentsList);
+        } else if (this.predicate.equals(PREDICATE_SHOW_DRAFT_INCIDENT_REPORTS)) {
+            resultMessage = handleDraftIncidents(model, filteredIncidentsList);
+        } else if (this.predicate.equals(PREDICATE_SHOW_COMPLETE_INCIDENT_REPORTS)) {
+            resultMessage = handleCompleteIncidents(model, filteredIncidentsList);
+        } else {
+            resultMessage = MESSAGE_FAIL;
+        }
+
+        return new CommandResult(resultMessage);
+    }
+
+    /**
+     * Handles the case for listing all incidents.
+     * @param model current model operated on by command
+     * @param incidents list of incidents to update
+     * @return string representing command result
+     */
+    private String handleAllIncidents(Model model, FilteredList<Incident> incidents) {
+        if (incidents.isEmpty()) {
+            return MESSAGE_NO_INCIDENTS;
+        } else {
+            model.updateFilteredIncidentList(predicate);
+            return MESSAGE_ALL_INCIDENTS;
+        }
+    }
+
+    /**
+     * Handles the case for listing all draft incidents.
+     * @param model current model operated on by command
+     * @param incidents list of incidents to update
+     * @return string representing command result
+     */
+    private String handleDraftIncidents(Model model, FilteredList<Incident> incidents) {
+        if (incidents.isEmpty()) {
+            return MESSAGE_NO_DRAFTS_TO_FILL;
+        } else {
+            model.updateFilteredIncidentList(predicate);
+            return MESSAGE_ALL_DRAFT_INCIDENTS;
+        }
+    }
+
+    /**
+     * Handles the case for listing all complete incidents.
+     * @param model current model operated on by command
+     * @param incidents list of incidents to update
+     * @return string representing command result
+     */
+    private String handleCompleteIncidents(Model model, FilteredList<Incident> incidents) {
+        if (incidents.isEmpty()) {
+            return MESSAGE_NO_INCIDENT_TO_SUBMIT;
+        } else {
+            model.updateFilteredIncidentList(predicate);
+            return MESSAGE_ALL_COMPLETE_INCIDENTS;
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SubmitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SubmitCommand.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_COMPLETE_INCIDENT_REPORTS;
 
-import java.util.function.Predicate;
+import java.util.List;
 
-import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -20,26 +20,22 @@ public class SubmitCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Submits completed incident reports.\n"
             + "Use " + COMMAND_WORD + " without parameters to list all completed reports.\n"
             + "Use " + COMMAND_WORD + " with parameters:"
-            + COMMAND_WORD + " i/INDEX (positive integer) to submit the specified draft.";
+            + COMMAND_WORD + " INDEX (positive integer) to submit the specified draft.";
 
     public static final String MESSAGE_SUBMIT_SUCCESS = "New incident report submitted: %1$s";
-    public static final String MESSAGE_COMPLETED_REPORTS_LISTED_SUCCESS = "Completed incident reports listed!";
-    public static final String MESSAGE_NO_COMPLETED_REPORTS_TO_SUBMIT = "No reports ready for submission!";
+    public static final String MESSAGE_NO_COMPLETED_REPORTS_TO_SUBMIT = "No reports ready for submission";
+    public static final String MESSAGE_DRAFT_IS_INCOMPLETE = "This draft is incomplete and is not ready for submission"
+            + " Please use the 'Fill' command to first complete the report";
+    public static final String MESSAGE_REPORT_HAS_BEEN_SUBMITTED = "This report has already been submitted";
 
     private final Index targetIndex;
-
-    /**
-     * Constructor for submit command without parameters.
-     */
-    public SubmitCommand() {
-        this.targetIndex = null;
-    }
 
     /**
      * Constructor for submit command with parameters.
      * @param index {@code Index} of completed report to submit.
      */
     public SubmitCommand(Index index) {
+        requireNonNull(index);
         this.targetIndex = index;
     }
 
@@ -47,34 +43,61 @@ public class SubmitCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // predicate to obtain completed incident reports
-        Predicate<Incident> predicate = Incident::isComplete;
-
-        // show filtered drafts
-        model.updateFilteredIncidentList(predicate);
-
-        // get filtered list
-        FilteredList<Incident> temp = model.getFilteredIncidentList().filtered(predicate);
-
-        if (temp.isEmpty()) {
+        if (!model.ifAnyIncidentsSatisfyPredicate(PREDICATE_SHOW_COMPLETE_INCIDENT_REPORTS)) {
             return new CommandResult(MESSAGE_NO_COMPLETED_REPORTS_TO_SUBMIT);
         }
 
-        // fill chosen draft
-        if (this.targetIndex != null) {
+        // there are drafts to be submitted. Get the last shown list.
+        List<Incident> lastShownList = model.getFilteredIncidentList();
 
-            if (targetIndex.getZeroBased() >= temp.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_INCIDENT_INDEX);
-            }
-
-            Incident toSubmit = temp.get(targetIndex.getZeroBased());
-            Incident updatedIncident = Incident.submitReport(toSubmit);
-            model.setIncident(toSubmit, updatedIncident);
-
-            return new CommandResult(String.format(MESSAGE_SUBMIT_SUCCESS, toSubmit));
+        // throw exception if index specified is out of bounds
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_INCIDENT_INDEX);
         }
 
-        return new CommandResult(MESSAGE_COMPLETED_REPORTS_LISTED_SUCCESS);
+        // retrieve incident and try to submit it
+        Incident toSubmit = lastShownList.get(targetIndex.getZeroBased());
+        return new CommandResult(processReportSubmission(model, toSubmit));
+    }
+
+    /**
+     * Processes submission of given incident report. The incident report is submitted if it is a complete draft and
+     * not submitted if it is an incomplete draft or if it has already been submitted.
+     * @param model current model to be modified by command
+     * @param toSubmit incident report to be submitted
+     * @return the string representing the command result
+     */
+    private String processReportSubmission(Model model, Incident toSubmit) {
+        // if incident is not a complete draft, do not allow submission
+        if (toSubmit.isIncompleteDraft()) {
+            return MESSAGE_DRAFT_IS_INCOMPLETE;
+        } else if (toSubmit.isSubmitted()) {
+            return MESSAGE_REPORT_HAS_BEEN_SUBMITTED;
+        }
+
+        // submit incident as it is a complete draft
+        Incident updatedIncident = submitReport(toSubmit);
+
+        // old incident is removed from the list, and replaced by the updated incident
+        // updated incident is appended to front of the list
+        model.removeIncident(toSubmit);
+        model.addIncident(updatedIncident);
+        return String.format(MESSAGE_SUBMIT_SUCCESS, toSubmit);
+    }
+
+    /**
+     * Submits specified incident by returning a new incident which is a copy of the old incident with 'Submitted'
+     * status.
+     * Triggered by 'submit' command.
+     * @param toSubmit the incident report to be submitted.
+     * @return updated incident report.
+     */
+    public Incident submitReport(Incident toSubmit) {
+        Incident updatedIncident = new Incident(toSubmit.getOperator(), toSubmit.getDistrict(),
+                toSubmit.getIncidentDateTime(), toSubmit.getIncidentId(), toSubmit.getCallerNumber(),
+                toSubmit.getDesc());
+        updatedIncident.setStatusAsSubmitted();
+        return updatedIncident;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,7 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PASSWORD = new Prefix("w/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_CALLER_NUMBER = new Prefix("c/");
-    public static final Prefix PREFIX_INDEX = new Prefix("i/");
     public static final Prefix PREFIX_DATETIME = new Prefix("dt/");
     public static final Prefix PREFIX_LOCATION = new Prefix("l/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");

--- a/src/main/java/seedu/address/logic/parser/FillCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FillCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CALLER_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import java.util.stream.Stream;
 
@@ -24,15 +23,20 @@ public class FillCommandParser implements Parser<FillCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FillCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX, PREFIX_CALLER_NUMBER,
-                PREFIX_DESCRIPTION);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CALLER_NUMBER, PREFIX_DESCRIPTION);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_INDEX, PREFIX_CALLER_NUMBER, PREFIX_DESCRIPTION)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_CALLER_NUMBER, PREFIX_DESCRIPTION)
+                || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FillCommand.MESSAGE_USAGE));
         }
 
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FillCommand.MESSAGE_USAGE), pe);
+        }
+
         CallerNumber callerNumber = ParserUtil.parseCallerNumber(argMultimap.getValue(PREFIX_CALLER_NUMBER).get());
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
 

--- a/src/main/java/seedu/address/logic/parser/IncidentManagerParser.java
+++ b/src/main/java/seedu/address/logic/parser/IncidentManagerParser.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INCIDENTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_COMPLETE_INCIDENT_REPORTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_DRAFT_INCIDENT_REPORTS;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -84,7 +87,7 @@ public class IncidentManagerParser {
             }
 
         case ListIncidentsCommand.COMMAND_WORD:
-            return new ListIncidentsCommand();
+            return new ListIncidentsCommand(PREDICATE_SHOW_ALL_INCIDENTS);
 
         case ListVehiclesCommand.COMMAND_WORD:
             return new ListVehiclesCommand();
@@ -109,14 +112,14 @@ public class IncidentManagerParser {
 
         case SubmitCommand.COMMAND_WORD:
             if (arguments.isEmpty()) {
-                return new SubmitCommand();
+                return new ListIncidentsCommand(PREDICATE_SHOW_COMPLETE_INCIDENT_REPORTS);
             } else {
                 return new SubmitCommandParser().parse(arguments);
             }
 
         case FillCommand.COMMAND_WORD:
             if (arguments.isEmpty()) {
-                return new FillCommand(); // TODO remove nulls by merging / inheriting commands
+                return new ListIncidentsCommand(PREDICATE_SHOW_DRAFT_INCIDENT_REPORTS);
             } else {
                 return new FillCommandParser().parse(arguments);
             }

--- a/src/main/java/seedu/address/logic/parser/SubmitCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SubmitCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import java.util.stream.Stream;
 
@@ -20,16 +19,13 @@ public class SubmitCommandParser implements Parser<SubmitCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public SubmitCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_INDEX)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SubmitCommand.MESSAGE_USAGE));
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new SubmitCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SubmitCommand.MESSAGE_USAGE), pe);
         }
-
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
-
-        return new SubmitCommand(index);
     }
 
     /**

--- a/src/main/java/seedu/address/model/IncidentManager.java
+++ b/src/main/java/seedu/address/model/IncidentManager.java
@@ -127,7 +127,7 @@ public class IncidentManager implements ReadOnlyIncidentManager {
     //// incident-level operation
 
     /**
-     * Returns true if an incident with the same identity as {@code incident} exists in the address book.
+     * Returns true if an incident with the same identity as {@code incident} exists in the incident manager.
      */
     public boolean hasIncident(Incident incident) {
         requireNonNull(incident);
@@ -135,11 +135,19 @@ public class IncidentManager implements ReadOnlyIncidentManager {
     }
 
     /**
-     * Adds an incident to the address book.
-     * The incident must not already exist in the address book.
+     * Adds an incident to the incident manager.
+     * The incident must not already exist in the incident manager.
      */
     public void addIncident(Incident i) {
         incidents.add(i);
+    }
+
+    /**
+     * Removes an incident to the incident manager.
+     * The incident must not already exist in the incident manager.
+     */
+    public void removeIncident(Incident i) {
+        incidents.remove(i);
     }
 
     //// vehicle-level operation

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -25,6 +25,9 @@ public interface Model {
     /** {@code Predicate} for filtering draft incident reports */
     Predicate<Incident> PREDICATE_SHOW_DRAFT_INCIDENT_REPORTS = Incident::isDraft;
 
+    /** {@code Predicate} for filtering complete incident reports */
+    Predicate<Incident> PREDICATE_SHOW_COMPLETE_INCIDENT_REPORTS = Incident::isCompleteDraft;
+
     /**
      * Sets the {@code Person} that is logged into the {@code Session}.
      */
@@ -84,33 +87,34 @@ public interface Model {
     ReadOnlyIncidentManager getIncidentManager();
 
     /**
-     * Returns true if a person with the same identity as {@code person} exists in the address book.
+     * Returns true if a person with the same identity as {@code person} exists in the incident manager.
      */
     boolean hasPerson(Person person);
 
     /**
      * Deletes the given person.
-     * The person must exist in the address book.
+     * The person must exist in the incident manager.
      */
     void deletePerson(Person target);
 
     /**
      * Adds the given person.
-     * {@code person} must not already exist in the address book.
+     * {@code person} must not already exist in the incident manager.
      */
     void addPerson(Person person);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
-     * {@code target} must exist in the address book.
-     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     * {@code target} must exist in the incident manager.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the incident
+     * manager.
      */
     void setPerson(Person target, Person editedPerson);
 
     /**
      * Replaces the given incident {@code target} with {@code editedIncident}.
-     * {@code target} must exit in the address book.
-     * Incident details of {@code target} must not be the same as another existing incident in address book.
+     * {@code target} must exit in the incident manager.
+     * Incident details of {@code target} must not be the same as another existing incident in incident manager.
      */
     void setIncident(Incident target, Incident editedIncident);
 
@@ -118,18 +122,27 @@ public interface Model {
     ObservableList<Person> getFilteredPersonList();
 
     /**
-     * Returns true if an incident with the same identity as {@code incident} exists in the address book.
+     * Returns true if an incident with the same identity as {@code incident} exists in the incident manager.
      */
     boolean hasIncident(Incident incident);
 
     /**
      * Adds the given incident.
-     * {@code incident} must not already exist in the address book.
+     * {@code incident} must not already exist in the incident manager.
      */
     void addIncident(Incident incident);
 
+    /**
+     * Removes the given incident.
+     * The {@code incident} must exist in the incident manager.
+     */
+    void removeIncident(Incident incident);
+
     /** Returns an unmodifiable view of the filtered incident list */
     ObservableList<Incident> getFilteredIncidentList();
+
+    /** Returns true if incident list contains incidents filtered by given predicate */
+    boolean ifAnyIncidentsSatisfyPredicate(Predicate<Incident> predicate);
 
     /** Returns an unmodifiable view of the filtered vehicle list */
     ObservableList<Vehicle> getFilteredVehicleList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -179,6 +179,11 @@ public class ModelManager implements Model {
         updateFilteredIncidentList(PREDICATE_SHOW_ALL_INCIDENTS);
     }
 
+    @Override
+    public void removeIncident(Incident incident) {
+        incidentManager.removeIncident(incident);
+    }
+
     //=========== Filtered Incident List Accessors =============================================================
 
     /**
@@ -194,6 +199,14 @@ public class ModelManager implements Model {
     public void updateFilteredIncidentList(Predicate<Incident> predicate) {
         requireNonNull(predicate);
         filteredIncidents.setPredicate(predicate);
+    }
+
+    /**
+     * Checks if the list contains incidents satisfying a given predicate.
+     * @return true if the list contains incidents satisfying given predicate, false otherwise.
+     */
+    public boolean ifAnyIncidentsSatisfyPredicate(Predicate<Incident> predicate) {
+        return !filteredIncidents.filtered(predicate).isEmpty();
     }
 
     //=========== Filtered Vehicle List Accessors =============================================================

--- a/src/main/java/seedu/address/model/incident/Incident.java
+++ b/src/main/java/seedu/address/model/incident/Incident.java
@@ -1,7 +1,5 @@
 package seedu.address.model.incident;
 
-import static seedu.address.model.util.SampleDataUtil.getTagSet;
-
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,14 +47,15 @@ public class Incident {
     private CallerNumber callerNumber;
 
     /** Enum to track incident status. */
-    // draft - not all fields filled AND not submitted.
-    // complete - all fields filled AND not submitted.
-    // final - all fields filled AND submitted.
+    // incomplete draft - not all fields filled AND not submitted.
+    // complete draft - all fields filled AND not submitted.
+    // submitted report - all fields filled AND submitted.
     private enum Status {
-        DRAFT, COMPLETE, FINAL
+        INCOMPLETE_DRAFT, COMPLETE_DRAFT, SUBMITTED_REPORT
     }
 
-    private Status status = Status.DRAFT; // default is draft
+    // TODO delete this field once all constructors accept status as attribute.
+    private Status status = Status.INCOMPLETE_DRAFT; // default is draft
 
     /** Constructor for generating an incident draft according to 'new' command i.e. fills auto-filled fields.
      * @param operator operator generating the new incident report.
@@ -69,7 +68,7 @@ public class Incident {
         this.incidentDateTime = new IncidentDateTime();
         this.id = new IncidentId(incidentDateTime.getMonth(), incidentDateTime.getYear());
 
-        this.status = Status.DRAFT; // newly created report
+        this.status = Status.INCOMPLETE_DRAFT; // newly created report
 
         // set to null as they will be filled in later
         this.description = null;
@@ -107,38 +106,13 @@ public class Incident {
      * Constructor for generating an incident draft according to 'fill' command i.e. all fields filled.
      */
     public Incident(Person operator, District location, IncidentDateTime incidentDateTime, IncidentId incidentId,
-                    CallerNumber callerNumber, Description description, Status status) {
+                    CallerNumber callerNumber, Description description) {
         this.operator = operator;
         this.location = location;
         this.incidentDateTime = incidentDateTime;
         this.id = incidentId;
         this.callerNumber = callerNumber;
         this.description = description;
-        this.status = status;
-    }
-
-    /**
-     * Returns a new updated incident report by filling callerNumber and description fields.
-     * Triggered by 'fill' command.
-     * @param toUpdate the incident to be filled.
-     * @param callerNumber phone number of the caller reporting the incident.
-     * @param description description of this incident.
-     * @return updated incident report.
-     */
-    public static Incident updateReport(Incident toUpdate, CallerNumber callerNumber, Description description) {
-        return new Incident(toUpdate.getOperator(), toUpdate.getDistrict(), toUpdate.getIncidentDateTime(),
-                toUpdate.getIncidentId(), callerNumber, description, Status.COMPLETE);
-    }
-
-    /**
-     * Returns a new updated incident report by filling callerNumber and description fields.
-     * Triggered by 'submit' command.
-     * @param toSubmit the incident report to be submitted.
-     * @return updated incident report.
-     */
-    public static Incident submitReport(Incident toSubmit) {
-        return new Incident(toSubmit.getOperator(), toSubmit.getDistrict(), toSubmit.getIncidentDateTime(),
-                toSubmit.getIncidentId(), toSubmit.getCallerNumber(), toSubmit.getDesc(), Status.FINAL);
     }
 
     public IncidentDateTime getDateTime() {
@@ -175,24 +149,36 @@ public class Incident {
                 .collect(Collectors.toSet());
     }
 
-    public Status getStatus() {
-        return status;
+    public void setStatusAsComplete() {
+        this.status = Status.COMPLETE_DRAFT;
+    }
+
+    public void setStatusAsSubmitted() {
+        this.status = Status.SUBMITTED_REPORT;
     }
 
     /**
-     * Checks if incident is a draft.
+     * Checks if incident is a complete or an incomplete draft.
      * @return true if incident is a draft, false otherwise.
      */
     public boolean isDraft() {
-        return this.status.equals(Status.DRAFT);
+        return this.status.equals(Status.COMPLETE_DRAFT) || this.status.equals(Status.INCOMPLETE_DRAFT);
     }
 
     /**
-     * Checks if incident is completely filled.
-     * @return true if incident is completely filled, false otherwise.
+     * Checks if incident is a complete draft ready for submission.
+     * @return true if incident is a complete draft, false otherwise.
      */
-    public boolean isComplete() {
-        return this.status.equals(Status.COMPLETE);
+    public boolean isCompleteDraft() {
+        return this.status.equals(Status.COMPLETE_DRAFT);
+    }
+
+    /**
+     * Checks if incident is an incomplete draft.
+     * @return true if incident is a incomplete draft, false otherwise.
+     */
+    public boolean isIncompleteDraft() {
+        return this.status.equals(Status.INCOMPLETE_DRAFT);
     }
 
     /**
@@ -200,7 +186,7 @@ public class Incident {
      * @return true if incident has been submitted, false otherwise.
      */
     public boolean isSubmitted() {
-        return this.status.equals(Status.FINAL);
+        return this.status.equals(Status.SUBMITTED_REPORT);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -170,12 +170,6 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        /*
-        @Override
-        public void updateFilteredIncidentList(Predicate<Incident> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }*/
-
         @Override
         public boolean hasIncident(Incident incident) {
             throw new AssertionError("This method should not be called.");
@@ -183,6 +177,11 @@ public class AddCommandTest {
 
         @Override
         public void addIncident(Incident incident) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void removeIncident(Incident incident) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -205,8 +204,14 @@ public class AddCommandTest {
         public void setIncident(Incident target, Incident editedIncident) {
             throw new AssertionError("This method should not be called.");
         }
+
         @Override
         public ObservableList<Vehicle> getFilteredVehicleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean ifAnyIncidentsSatisfyPredicate(Predicate<Incident> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/ListIncidentsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListIncidentsCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showIncidentAtIndex;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INCIDENTS;
 import static seedu.address.testutil.TypicalEntities.getTypicalIncidentManager;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTITY;
 
@@ -28,12 +29,14 @@ public class ListIncidentsCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListIncidentsCommand(), model, ListIncidentsCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListIncidentsCommand(PREDICATE_SHOW_ALL_INCIDENTS), model,
+                ListIncidentsCommand.MESSAGE_ALL_INCIDENTS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showIncidentAtIndex(model, INDEX_FIRST_ENTITY);
-        assertCommandSuccess(new ListIncidentsCommand(), model, ListIncidentsCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListIncidentsCommand(PREDICATE_SHOW_ALL_INCIDENTS), model,
+                ListIncidentsCommand.MESSAGE_ALL_INCIDENTS, expectedModel);
     }
 }


### PR DESCRIPTION
Resolves #159 

- Improved internal logic and code quality of `fill` and `submit`.

- Modified `ListIncidentsCommand` to list incidents according to a specified predicate. It is now used in three ways:
- list all incidents: using `list-i` command. 
- list all drafts (complete and incomplete): using `fill` command without parameters.
- list all complete drafts: using `submit` command without parameters.

- any time an incident is filled and/or submitted, it is now displayed at the top of the incident list.

@hellopanda128 for the `edit` incident command, you could consider using the `ListIncidentsCommand`  with a predicate that lists all submitted incidents that are valid to be edited (if not users will be able to edit drafts with all statuses which interferes with the fill and submit commands). This will allow the user to identify which incident to edit before editing it (i.e. that's how they know what is the index of the incident they are editing). 